### PR TITLE
minor fixes to pickups 

### DIFF
--- a/Assets/Personal/Prefabs/Player.prefab
+++ b/Assets/Personal/Prefabs/Player.prefab
@@ -644,8 +644,9 @@ MonoBehaviour:
   pickupPrefabs:
   - {fileID: 1474425910296937359, guid: cdbd996c91ee4fb43b146ecf6b0e0639, type: 3}
   - {fileID: 9062464723520462773, guid: 39a0ba106127d264f87db8bf5dd0a99f, type: 3}
-  nextSpawn: 5
   pickupLimit: 10
+  upperBoundTime: 20
+  lowerBoundTime: 40
 --- !u!1001 &2368544253589646412
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Personal/Scripts/Pickup Scripts/HealthPickup.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/HealthPickup.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class HealthPickup : MonoBehaviour
 {
-    private int HealthAmount = 50;
+    [SerializeField] private int HealthAmount = 50;
 
     // called once per frame
 
@@ -18,8 +18,8 @@ public class HealthPickup : MonoBehaviour
         if (col.gameObject.tag == "Player")
         {
             col.gameObject.GetComponent<PlayerHealth>().GainHealth(HealthAmount);
-            Destroy(gameObject);
             col.gameObject.GetComponent<PickupSpawner>().PickedUp();
+            Destroy(gameObject);
         }
         if (col.gameObject.tag == "Enemy")
         {

--- a/Assets/Personal/Scripts/Pickup Scripts/PickupSpawner.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/PickupSpawner.cs
@@ -7,10 +7,12 @@ public class PickupSpawner : MonoBehaviour
     [SerializeField] GameObject[] pickupPrefabs;
     TetherController[] tethersTracker;
     float spawnTimer;
-    [SerializeField] float nextSpawn;
+    float nextSpawn;
     int pickupCount;
     [SerializeField] int pickupLimit;
     //GameObject[] pickup;
+    [SerializeField] float upperBoundTime;
+    [SerializeField] float lowerBoundTime;
 
     // Start is called before the first frame update
     void Start()
@@ -33,9 +35,15 @@ public class PickupSpawner : MonoBehaviour
 
     bool CheckSpawn()
     {
+        nextSpawn = Random.Range(lowerBoundTime, upperBoundTime);
         if (spawnTimer >= nextSpawn && pickupCount < pickupLimit)
         {
             return true;
+        }
+        else if (spawnTimer >= nextSpawn && pickupCount >= pickupLimit)
+        {
+            spawnTimer = 0;
+            return false;
         }
         else return false;
     }

--- a/Assets/Personal/Scripts/Pickup Scripts/StaminaPickup.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/StaminaPickup.cs
@@ -16,9 +16,9 @@ public class StaminaPickup : MonoBehaviour
     {
         if (col.gameObject.tag == "Player")
         {
-            col.gameObject.GetComponent<PlayerStamina>().GainStamina(StaminaAmount);
-            Destroy(gameObject);
+            col.gameObject.GetComponent<PlayerStamina>().RegainStaminaWithoutRegen(StaminaAmount);
             col.gameObject.GetComponent<PickupSpawner>().PickedUp();
+            Destroy(gameObject);
         }
        
        if (col.gameObject.tag == "Enemy")

--- a/Assets/Personal/Scripts/Player Scripts/PlayerStamina.cs
+++ b/Assets/Personal/Scripts/Player Scripts/PlayerStamina.cs
@@ -65,7 +65,7 @@ public class PlayerStamina : MonoBehaviour
         }
     }
 
-    public void GainStamina(int staminagain)
+    public void RegainStaminaWithoutRegen(int staminagain)
     {
         if ((staminagain + currentStamina) <= maxStamina & currentStamina >= 0)
         {

--- a/Assets/Scenes/VerticalArenaScene.unity
+++ b/Assets/Scenes/VerticalArenaScene.unity
@@ -3076,23 +3076,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 297547908}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &297547912
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 297547909}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4085562ee971b834e8d6d9267e81345c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  pickupPrefabs:
-  - {fileID: 1474425910296937359, guid: cdbd996c91ee4fb43b146ecf6b0e0639, type: 3}
-  - {fileID: 9062464723520462773, guid: 39a0ba106127d264f87db8bf5dd0a99f, type: 3}
-  nextSpawn: 5
-  pickupLimit: 10
 --- !u!1 &297591260
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I added minor changes to the pickups as recommended such as creating a upper bound and lower bound on time until the next spawn of the pickup. They are serialized fields so they can be changes easily depending on how they balance out later in development. I made the timer on the next spawn reset every tick that there was a maximum amount of pickups on the ground so that when a player picked up a new pickup a new one would not instantly spawn. I also changed the name of the stamina gain function associated with the stamina pickup to staminagainwithoutregen to indicate that it is separate from the normal regen of the stamina.