### PR TITLE
Overshield Pickup!

### DIFF
--- a/Assets/Personal/Prefabs/Player.prefab
+++ b/Assets/Personal/Prefabs/Player.prefab
@@ -453,6 +453,7 @@ MonoBehaviour:
     flashColor: {r: 1, g: 0, b: 0, a: 0.50980395}
     maxHealth: 100
     hitSound: {fileID: 8300000, guid: 561f895606b5cff4085fe1a7e5586ad3, type: 3}
+    overshieldBar: {fileID: 0}
   movementValues:
     speed: 10
     stickToGroundForce: 10
@@ -618,8 +619,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   totalEnemiesInWave: 20
   timeBetweenWaves: 7
+  timeBetweenSubWaves: 10
   spawnManager: {fileID: 744898450}
-  difficultyManager: {fileID: 744898441}
 --- !u!114 &744898452
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -662,11 +663,12 @@ MonoBehaviour:
   pickupPrefabs:
   - {fileID: 1474425910296937359, guid: cdbd996c91ee4fb43b146ecf6b0e0639, type: 3}
   - {fileID: 9062464723520462773, guid: 39a0ba106127d264f87db8bf5dd0a99f, type: 3}
-  pickupLimit: 4
-  upperBoundTime: 7
-  lowerBoundTime: 7
+  - {fileID: 8681397256562117913, guid: 124b23de537ba5f4aa21cce0451207d0, type: 3}
+  pickupLimit: 3
+  upperBoundTime: 20
+  lowerBoundTime: 30
   pickupsParent: {fileID: 0}
-  despawnTime: 45
+  despawnTime: 50
 --- !u!1001 &2368544253589646412
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Personal/Prefabs/overshieldpickup.prefab
+++ b/Assets/Personal/Prefabs/overshieldpickup.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 6880671160938873924}
   - component: {fileID: 7198185888200458303}
   - component: {fileID: 5390431418210057897}
+  - component: {fileID: 8778701859319456358}
   m_Layer: 13
   m_Name: overshieldpickup
   m_TagString: Pickup
@@ -91,3 +92,17 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8778701859319456358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8681397256562117913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7f5524aec4ba76458eee53558dfccd2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timer: 0
+  OvershieldAmount: 25

--- a/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OvershieldPickup : PickupController
+{
+    [SerializeField] private float OvershieldAmount = 25;
+
+
+private void OnTriggerEnter(Collider col)
+{
+    col.gameObject.GetComponent<PlayerHealth>().GainOvershield(OvershieldAmount);
+    col.gameObject.GetComponent<PickupSpawner>().PickedUp(gameObject);
+}
+}

--- a/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class OvershieldPickup : PickupController
 {
-    [SerializeField] private float OvershieldAmount = 25;
+    [SerializeField] public float OvershieldAmount;
 
 
 private void OnTriggerEnter(Collider col)

--- a/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs.meta
+++ b/Assets/Personal/Scripts/Pickup Scripts/OvershieldPickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7f5524aec4ba76458eee53558dfccd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Personal/Scripts/Pickup Scripts/PickupSpawner.cs
+++ b/Assets/Personal/Scripts/Pickup Scripts/PickupSpawner.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PickupSpawner : MonoBehaviour
 {
-    public enum PickupType : int { HealthPickup, StaminaPickup };
+    public enum PickupType : int { HealthPickup, StaminaPickup, OvershieldPickup };
     [SerializeField] GameObject[] pickupPrefabs;
     TetherController[] tethersTracker;
     List<GameObject> pickups = new List<GameObject>(); //tracks pickups -- used for pickup despawning
@@ -18,7 +18,7 @@ public class PickupSpawner : MonoBehaviour
     [SerializeField] float lowerBoundTime;
     [SerializeField] GameObject pickupsParent;
     [SerializeField] float despawnTime;
-    float[] spawnChances = { 0.5f, 1.0f }; //Goes from 0 to 1 to control spawn rate chances.
+    float[] spawnChances = { 0.4f, 0.8f, 1.0f }; //Goes from 0 to 1 to control spawn rate chances.
 
     // Start is called before the first frame update
     void Start()

--- a/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
+++ b/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
@@ -21,6 +21,7 @@ public class PlayerHealth : MonoBehaviour
     PlayerValues playerValues;
     AudioSource audioSource;
     AudioClip hitSound;
+    private float overshieldMax;
 
     // Use this for initialization
     void Start()
@@ -38,6 +39,7 @@ public class PlayerHealth : MonoBehaviour
         maxHealth = playerValues.healthValues.MaxHealth;
         hitSound = playerValues.healthValues.HitSound;
         overshieldBar = playerValues.healthValues.OvershieldBar;
+        overshieldMax = gameObject.GetComponent<OvershieldPickup>().OvershieldAmount;
 
         health = maxHealth;
         healthBar.type = Image.Type.Filled;
@@ -58,7 +60,7 @@ public class PlayerHealth : MonoBehaviour
         if(overshield > 0)
         {
             overshield -= 2*Time.deltaTime;
-            overshieldBar.fillAmount = overshield / 25;
+            overshieldBar.fillAmount = overshield / overshieldMax;
         }
         if (damaged)
         {
@@ -78,7 +80,7 @@ public class PlayerHealth : MonoBehaviour
             if (overshield > damage)
             {
                 overshield -= damage;
-                overshieldBar.fillAmount = overshield / 25;
+                overshieldBar.fillAmount = overshield / overshieldMax;
                 return;
             }
             if (overshield > 0 && overshield < damage)

--- a/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
+++ b/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
@@ -39,7 +39,7 @@ public class PlayerHealth : MonoBehaviour
         maxHealth = playerValues.healthValues.MaxHealth;
         hitSound = playerValues.healthValues.HitSound;
         overshieldBar = playerValues.healthValues.OvershieldBar;
-        overshieldMax = gameObject.GetComponent<OvershieldPickup>().OvershieldAmount;
+        overshieldMax = 0;
 
         health = maxHealth;
         healthBar.type = Image.Type.Filled;
@@ -105,6 +105,7 @@ public class PlayerHealth : MonoBehaviour
 
     public void GainOvershield (float overshieldgain)
     {
+        overshieldMax = overshieldgain;
         overshield = overshieldgain;
         overshieldBar.fillAmount = 1f;
     }

--- a/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
+++ b/Assets/Personal/Scripts/Player Scripts/PlayerHealth.cs
@@ -7,12 +7,14 @@ public class PlayerHealth : MonoBehaviour
 {
     Image healthBar;
     Image damageImage;
+    Image overshieldBar;
     Text gameOverText;
     [SerializeField] Canvas gameOverCanvas;
     float flashSpeed = 5f;
     Color flashColor = new Color(1f, 0f, 0f, 0.1f);
     private int maxHealth;
     private float health;
+    private float overshield;
     private bool damaged;
     private ImpactReceiver impactReceiver;
     PlayerMover playerMover;
@@ -35,19 +37,29 @@ public class PlayerHealth : MonoBehaviour
         flashColor = playerValues.healthValues.FlashColor;
         maxHealth = playerValues.healthValues.MaxHealth;
         hitSound = playerValues.healthValues.HitSound;
+        overshieldBar = playerValues.healthValues.OvershieldBar;
 
         health = maxHealth;
         healthBar.type = Image.Type.Filled;
         healthBar.fillMethod = Image.FillMethod.Horizontal;
         //healthBar.fillAmount = 1f;
+        overshieldBar.type = Image.Type.Filled;
+        overshieldBar.fillMethod = Image.FillMethod.Horizontal;
 
         //added for testing purposes
         healthBar.fillAmount = health / maxHealth;
+
+        overshieldBar.fillAmount = 0;
     }
 
     // Update is called once per frame
     void Update()
     {
+        if(overshield > 0)
+        {
+            overshield -= 2*Time.deltaTime;
+            overshieldBar.fillAmount = overshield / 25;
+        }
         if (damaged)
         {
             damageImage.color = flashColor;
@@ -63,6 +75,18 @@ public class PlayerHealth : MonoBehaviour
     {
         if (playerMover.isVulnerable())
         {
+            if (overshield > damage)
+            {
+                overshield -= damage;
+                overshieldBar.fillAmount = overshield / 25;
+                return;
+            }
+            if (overshield > 0 && overshield < damage)
+            {
+                damage -= (int)overshield;
+                overshield = 0;
+                overshieldBar.fillAmount = 0f;
+            }
             health -= damage;
             damaged = true;
             healthBar.fillAmount = health / maxHealth;
@@ -77,7 +101,12 @@ public class PlayerHealth : MonoBehaviour
         }
     }
 
-    //added by CALEB
+    public void GainOvershield (float overshieldgain)
+    {
+        overshield = overshieldgain;
+        overshieldBar.fillAmount = 1f;
+    }
+
     public void GainHealth(int healthgain)
     {
         if ((healthgain + health) <= maxHealth && health > 0)

--- a/Assets/Personal/Scripts/Player Scripts/PlayerValues.cs
+++ b/Assets/Personal/Scripts/Player Scripts/PlayerValues.cs
@@ -191,6 +191,8 @@ public class PlayerValues : ActorValues
         [SerializeField] private int maxHealth;
         [SerializeField] private AudioClip hitSound;
 
+        [SerializeField] private Image overshieldBar;
+
         public float FlashSpeed
         {
             get
@@ -201,6 +203,14 @@ public class PlayerValues : ActorValues
             set
             {
                 flashSpeed = value;
+            }
+        }
+
+        public Image OvershieldBar
+        {
+            get
+            {
+                return overshieldBar;
             }
         }
 

--- a/Assets/Personal/Shaders/Overshield_pickup.mat
+++ b/Assets/Personal/Shaders/Overshield_pickup.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Overshield_pickup
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 1, g: 0.7764706, b: 0, a: 1}

--- a/Assets/Personal/Shaders/Overshield_pickup.mat.meta
+++ b/Assets/Personal/Shaders/Overshield_pickup.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71617b3d063e7924d908ef9b5eb99f74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/VerticalArenaScene.unity
+++ b/Assets/Scenes/VerticalArenaScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.45002985, g: 0.5000846, b: 0.5755015, a: 1}
+  m_IndirectSpecularColor: {r: 0.45002955, g: 0.5000841, b: 0.5755014, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3063,6 +3063,11 @@ PrefabInstance:
       propertyPath: generalValues.pauseMenu
       value: 
       objectReference: {fileID: 1872307368}
+    - target: {fileID: 3606967138850372387, guid: 24702d2c502ac224ca4a638da8a5acdc,
+        type: 3}
+      propertyPath: healthValues.overshieldBar
+      value: 
+      objectReference: {fileID: 457279336}
     - target: {fileID: 744898450, guid: 24702d2c502ac224ca4a638da8a5acdc, type: 3}
       propertyPath: enemyPrefabs.Array.data[0]
       value: 
@@ -3084,6 +3089,11 @@ PrefabInstance:
         type: 3}
       propertyPath: despawnTime
       value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1439987890184473724, guid: 24702d2c502ac224ca4a638da8a5acdc,
+        type: 3}
+      propertyPath: upperBoundTime
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 1851651619850872098, guid: 24702d2c502ac224ca4a638da8a5acdc,
         type: 3}
@@ -4450,6 +4460,80 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 455543864}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &457279334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 457279335}
+  - component: {fileID: 457279337}
+  - component: {fileID: 457279336}
+  m_Layer: 5
+  m_Name: OvershieldBar
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &457279335
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457279334}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1302236825}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 95, y: 25}
+  m_SizeDelta: {x: 160, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &457279336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457279334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 71617b3d063e7924d908ef9b5eb99f74, type: 2}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 0626b924325d1c34cafa6b22297f4e4f, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &457279337
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457279334}
+  m_CullTransparentMesh: 0
 --- !u!1 &459574258
 GameObject:
   m_ObjectHideFlags: 0
@@ -12725,6 +12809,12 @@ OffMeshLink:
   m_BiDirectional: 0
   m_Activated: 1
   m_AutoUpdatePositions: 0
+--- !u!224 &1302236825 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224613261759428000, guid: 48c615876cd04284fa34b061c89d7905,
+    type: 3}
+  m_PrefabInstance: {fileID: 1414270660}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1309747690
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.0f2
+m_EditorVersion: 2018.3.7f1


### PR DESCRIPTION
So I tried to do all of my stuff really early this time since Malloc is upon me and also because I wanted it to be in the showcase this Saturday. So really all I added was the overshield pickup, but it is different from the other pickups in that it touches more scripts than usual and more functions than usual. Right now the overshield pickup gives the player a sort of 25 overshield or armor, 1 overshield being equivalent to 1 health, and as soon as the player grabs the overshield, it fills up the overshield bar and immediately begins to drain regardless of whether or not the player is taking damage. 25 might have seemed OP at first but since the shield drains fairly quickly I think this is a good balance. Also, for now the 25 overshield is hard-coded so I do not recommend changing it as of now, but instead to change the rate at which the overshield depletes. To be clear, the overshield does not stay at 25 and after a time go to 0 but continuously goes from 25 to 0. As you will see the overshield bar is in the player values scripts, and the overshield amount is in the TakeDamage function. It is fairly simple, if the player takes damage and he/she has overshield then it will do damage to the overshield and if not then it will do damage to the health. I also added the case in which the damage done is greater than the overshield left in which case it would do initial damage to the overshield until it is depleted and then the remaining damage would go to the player health. Lastly, in the scene editor the overshield bar is shown as full, but when the game actually starts is disappears and this, at least to me, does not seem like a big deal since the player will never see the full bar before the game. I was going to opt for a grey or red background behind the overshield similar to the stamina and health bars but I felt this looked awkward with a blank bar just sitting there. 